### PR TITLE
specify httpd alpine version 2.4.35

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:alpine
+FROM httpd:2.4.35-alpine
 
 # These variables are inherited from the httpd:alpine image:
 # ENV HTTPD_PREFIX /usr/local/apache2


### PR DESCRIPTION
Apparently, the httpd-alpine version 2.4.37 has an issue with the mod_ssl, someone resolved using the version 2.4.35 https://github.com/docker-library/httpd/issues/115
Related to Issue #5