### PR TITLE
Fix non-ASCII filename garbled in web index page

### DIFF
--- a/2.4/conf/conf-available/dav.conf
+++ b/2.4/conf/conf-available/dav.conf
@@ -10,6 +10,8 @@ Alias / "/var/lib/dav/data/"
   <RequireAny>
     Require valid-user
   </RequireAny>
+
+  IndexOptions Charset=utf-8
 </Directory>
 
 # These disable redirects on non-GET requests for directories that


### PR DESCRIPTION
Fixes #18.

Credit-goes-to: CentOS7下安装Apache WebDAV教程 – NT宝贝网 <https://ntbaobei.com/?p=333>
Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>