### PR TITLE
Also enable socache_shmcb module to fix ssl error

### DIFF
--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -89,7 +89,7 @@ fi
 # has been bind mounted in by the user.
 if [ -e /privkey.pem ] && [ -e /cert.pem ]; then
     # Enable SSL Apache modules.
-    for i in http2 ssl; do
+    for i in http2 ssl socache_shmcb; do
         sed -e "/^#LoadModule ${i}_module.*/s/^#//" \
             -i "$HTTPD_PREFIX/conf/httpd.conf"
     done

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ This image runs an easily configurable WebDAV server with Apache.
 You can configure the authentication type, the authentication of multiple users, or to run with a self-signed SSL certificate. If you want a Let's Encrypt certificate, see an example of how to do that [here](https://github.com/BytemarkHosting/configs-webdav-docker).
 
 * **Code repository:**
-  https://github.com/BytemarkHosting/docker-webdav
+  Upstream: https://github.com/BytemarkHosting/docker-webdav  
+  This container: https://github.com/k3vmcd/docker-webdav
 * **Where to file issues:**
   https://github.com/BytemarkHosting/docker-webdav/issues
 * **Maintained by:**


### PR DESCRIPTION
Latest apache needs socache_shmcb enabled to fix error in Issue #5 and #17. This does not require version rollback in pull request #6.

Fix is implemented at: https://hub.docker.com/repository/docker/k3vmcd/webdav
Pull with `docker pull k3vmcd/webdav`

(When pulled, bump version number).