### PR TITLE
Add User-Agent match for Apache Commons VFS client

### DIFF
--- a/2.4/conf/conf-available/dav.conf
+++ b/2.4/conf/conf-available/dav.conf
@@ -23,3 +23,4 @@ BrowserMatch "^XML Spy" redirect-carefully
 BrowserMatch "^Dreamweaver-WebDAV-SCM1" redirect-carefully
 BrowserMatch " Konqueror/4" redirect-carefully
 BrowserMatch "^gvfs" redirect-carefully
+BrowserMatch "^Jakarta-Commons-VFS" redirect-carefully


### PR DESCRIPTION
Fixes problem with redirects for Apache Commons VFS client.

Similar problem was described in Issue #13. The only difference is the client which I'm using.

Default user-agent for Apache Commons VFS is `Jakarta-Commons-VFS`.

