### PR TITLE
Change entrypoint to work with read only mounts

### DIFF
--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -101,6 +101,6 @@ fi
 # Create directories for Dav data and lock database.
 [ ! -d "/var/lib/dav/data" ] && mkdir -p "/var/lib/dav/data"
 [ ! -e "/var/lib/dav/DavLock" ] && touch "/var/lib/dav/DavLock"
-chown -R www-data:www-data "/var/lib/dav"
+chown www-data:www-data "/var/lib/dav/data" "/var/lib/dav/DavLock"
 
 exec "$@"


### PR DESCRIPTION
The readme encourages use of mounting directories under `/var/lib/dav/data` but

1. It's bad practice to chown any volume/bind mounts to this directory because it might mess up permissions on the host machine
2. Trying to chown a readonly (`ro`) mount will fail and crash the container.

So I changed the chown commands to be more restrictive here to avoid those problems. Work fine for my own testing where I read only bind mount a directory under `/var/lib/dav/data`

This could possibly be version 2.5 but maybe worthwhile to combine with other changes. Thanks!