### PR TITLE
feat: add env var to specifiy where user auth file should be mounted

### DIFF
--- a/2.4/conf/conf-available/dav.conf
+++ b/2.4/conf/conf-available/dav.conf
@@ -6,7 +6,7 @@ Alias / "/var/lib/dav/data/"
 
   AuthType Basic
   AuthName "WebDAV"
-  AuthUserFile "/user.passwd"
+  AuthUserFile ${USER_PASSWD_FILE}
   <RequireAny>
     Require valid-user
   </RequireAny>

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 #   PASSWORD
 #   ANONYMOUS_METHODS
 #   SSL_CERT
+#   USER_PASSWD_FILE
 
 # Just in case this environment variable has gone missing.
 HTTPD_PREFIX="${HTTPD_PREFIX:-/usr/local/apache2}"
@@ -49,16 +50,17 @@ if [ "x$AUTH_TYPE" != "x" ]; then
 fi
 
 # Add password hash, unless "user.passwd" already exists (ie, bind mounted).
-if [ ! -e "/user.passwd" ]; then
-    touch "/user.passwd"
+USER_PASSWD_FILE="${USER_PASSWD_FILE:-/user.passwd}"
+if [ ! -e "$USER_PASSWD_FILE" ]; then
+    touch "$USER_PASSWD_FILE"
     # Only generate a password hash if both username and password given.
     if [ "x$USERNAME" != "x" ] && [ "x$PASSWORD" != "x" ]; then
         if [ "$AUTH_TYPE" = "Digest" ]; then
             # Can't run `htdigest` non-interactively, so use other tools.
             HASH="`printf '%s' "$USERNAME:$REALM:$PASSWORD" | md5sum | awk '{print $1}'`"
-            printf '%s\n' "$USERNAME:$REALM:$HASH" > /user.passwd
+            printf '%s\n' "$USERNAME:$REALM:$HASH" > $USER_PASSWD_FILE
         else
-            htpasswd -B -b -c "/user.passwd" $USERNAME $PASSWORD
+            htpasswd -B -b -c "$USER_PASSWD_FILE" $USERNAME $PASSWORD
         fi
     fi
 fi

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ If you bind mount a certificate chain to `/cert.pem` and a private key to `/priv
 
 ### Authenticate multiple clients
 
-Specifying `USERNAME` and `PASSWORD` only supports a single user. If you want to have lots of different logins for various users, bind mount your own file to `/user.passwd` and the container will use that instead.
+Specifying `USERNAME` and `PASSWORD` only supports a single user. If you want to have lots of different logins for various users, bind mount your own file using the `USER_PASSWD_FILE` environment variable and the container will use that instead.
 
 If using `Basic` authentication, run the following commands:
 
@@ -102,6 +102,6 @@ All environment variables are optional. You probably want to at least specify `U
 * **`REALM`**: Sets [AuthName](https://httpd.apache.org/docs/current/mod/mod_authn_core.html#authname), an identifier that is displayed to clients when they connect. The default is `WebDAV`.
 * **`USERNAME`**: Authenticate with this username (and the password below). This is ignored if you bind mount your own authentication file to `/user.passwd`.
 * **`PASSWORD`**: Authenticate with this password (and the username above). This is ignored if you bind mount your own authentication file to `/user.passwd`.
+* **`USER_PASSWD_FILE`**: Path of the user passwd file used for authentication. The default is `/user.passwd`.
 * **`ANONYMOUS_METHODS`**: Comma-separated list of HTTP request methods (eg, `GET,POST,OPTIONS,PROPFIND`). Clients can use any method you specify here without authentication. Set to `ALL` to disable authentication. The default is to disallow any anonymous access.
 * **`SSL_CERT`**: Set to `selfsigned` to generate a self-signed certificate and enable Apache's SSL module. If you specify `SERVER_NAMES`, the first domain is set as the Common Name.
-


### PR DESCRIPTION
Adds an Environment variable to configure where the `user.passwd` file should be. The variable defaults to where it was, `/user.passwd`.

Useful when you can only mount volumes/folders into the container and cannot mount to `/` (like with TrueNAS Scale)