### PR TITLE
pin the base image tag for compatibility; allow host editing of uploaded files

### DIFF
--- a/2.4/Dockerfile
+++ b/2.4/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:alpine
+FROM httpd:2.4.43-alpine
 
 # These variables are inherited from the httpd:alpine image:
 # ENV HTTPD_PREFIX /usr/local/apache2

--- a/2.4/docker-entrypoint.sh
+++ b/2.4/docker-entrypoint.sh
@@ -10,6 +10,7 @@ set -e
 #   PASSWORD
 #   ANONYMOUS_METHODS
 #   SSL_CERT
+#   LOCAL
 
 # Just in case this environment variable has gone missing.
 HTTPD_PREFIX="${HTTPD_PREFIX:-/usr/local/apache2}"
@@ -102,5 +103,12 @@ fi
 [ ! -d "/var/lib/dav/data" ] && mkdir -p "/var/lib/dav/data"
 [ ! -e "/var/lib/dav/DavLock" ] && touch "/var/lib/dav/DavLock"
 chown -R www-data:www-data "/var/lib/dav"
+
+# Give yourself the ability to manually
+# create and edit shared files
+if [ "x$LOCAL" != "x" ]; then
+    chmod o+w /var/lib/dav/data
+    umask 0021
+fi
 
 exec "$@"

--- a/README.md
+++ b/README.md
@@ -104,4 +104,4 @@ All environment variables are optional. You probably want to at least specify `U
 * **`PASSWORD`**: Authenticate with this password (and the username above). This is ignored if you bind mount your own authentication file to `/user.passwd`.
 * **`ANONYMOUS_METHODS`**: Comma-separated list of HTTP request methods (eg, `GET,POST,OPTIONS,PROPFIND`). Clients can use any method you specify here without authentication. Set to `ALL` to disable authentication. The default is to disallow any anonymous access.
 * **`SSL_CERT`**: Set to `selfsigned` to generate a self-signed certificate and enable Apache's SSL module. If you specify `SERVER_NAMES`, the first domain is set as the Common Name.
-
+* **`LOCAL`**: Set to `true` to allow manual creation and edit of files on the mounted volume. Useful for local testing.


### PR DESCRIPTION
### Problem: latest Alpine is missing DBM libraries used by WebDAV module
The Dockerfile specifies `httpd:alpine` as a base, however when I build an image locally, run it, and test file upload, an error occurs similar to the issue described here: https://github.com/docker-library/httpd/issues/201#issue-1025232500
### Solution: use a Docker image tag that includes the required libs
Pin the base image to `httpd:2.4.43-alpine` which is the most recent tag that uses Alpine 3.12, which includes the required DBM libraries.

---

### Problem: files uploaded via WebDAV cannot be modified by the host
Upon startup, the entrypoint script changes ownership of all files and directories beneath and including the `/var/lib/dav` mount to the container user `www-data`. Newly created files are also owned by this user, and thus cannot be removed or modified by a non-root user on the host.

### Solution: allow host edits by using an optional environment variable
Introduce an optional environment variable `LOCAL` that changes the `umask` for newly created files and directories that allows edits by a host user, by default.